### PR TITLE
Fixed crash while reloading player with CMD+R

### DIFF
--- a/SoundcloudPlayer/SharedAudioPlayer.m
+++ b/SoundcloudPlayer/SharedAudioPlayer.m
@@ -254,7 +254,13 @@
     [self.streamItemsToShowInTableView removeAllObjects];
     [self.favoriteItemsToShowInTableView removeAllObjects];
     self.positionInPlaylist = 0;
-    self.audioPlayer = nil;
+    
+    if (self.audioPlayer != nil) {
+        
+        [self.audioPlayer removeObserver:self forKeyPath:@"status"];
+        self.audioPlayer = nil;
+    }
+
     self.shuffledItemsToPlay = nil;
     self.itemsToPlay = nil;
     self.shuffledItemsToPlay = [NSMutableArray array];


### PR DESCRIPTION
The observer wasn't removed before deallocation of audioPlayer property, so the app used to crash. 
Now it is fine.